### PR TITLE
<title>module function Foo.#bar</title>がmoduleとして認識され、keyが"function Foo.#bar"になっていたのを修正。

### DIFF
--- a/generate_docsets.rb
+++ b/generate_docsets.rb
@@ -76,7 +76,7 @@ Find.find(html_dir) do |file|
     end
 
     # class
-    if html =~ %r{<title>(class|module|object) (.*?)</title>}
+    if html =~ %r{<title>(class|module(?!\sfunction)|object) (.*?)</title>}
       item[:key] = CGI.unescapeHTML($2)
       item[:type] = $1.camelize
     end


### PR DESCRIPTION
モジュール関数が subject のように表示されていたので、moduleはマッチするけど、module function はマッチしないように修正してみました。
